### PR TITLE
Mutilidae fix for new MariaDB [T1200 fix]

### DIFF
--- a/docker-compose.acra-censor-demo.yml
+++ b/docker-compose.acra-censor-demo.yml
@@ -106,7 +106,7 @@ services:
         # Build base image
         build:
             context: https://github.com/storojs72/docker-mutillidae.git
-        image: edoz90_mutillidae:latest
+        image: storojs72/edoz90_mutillidae:latest
         # We don't need to run the container based on the original image
         entrypoint: /bin/true
         restart: 'no'

--- a/docker-compose.acra-censor-demo.yml
+++ b/docker-compose.acra-censor-demo.yml
@@ -103,9 +103,9 @@ services:
     #===== OWASP Mutillidae II =================================================
 
     edoz90_mutillidae:
-        # Build base image from edoz90/docker-mutillidae
+        # Build base image
         build:
-            context: https://github.com/edoz90/docker-mutillidae.git
+            context: https://github.com/storojs72/docker-mutillidae.git
         image: edoz90_mutillidae:latest
         # We don't need to run the container based on the original image
         entrypoint: /bin/true

--- a/mutillidae/Dockerfile
+++ b/mutillidae/Dockerfile
@@ -1,4 +1,4 @@
-FROM edoz90_mutillidae:latest
+FROM storojs72/edoz90_mutillidae:latest
 
 ADD ./configure_db.sh /tmp/configure_db.sh
 RUN /bin/bash /tmp/configure_db.sh

--- a/mutillidae/configure_db.sh
+++ b/mutillidae/configure_db.sh
@@ -8,7 +8,7 @@ MYSQL_DB='mutillidae'
 MYSQL_USER='mutillidae'
 MYSQL_PASSWORD='mutillidae'
 
-cat <<EOF | /usr/bin/mysqld --user=mysql --bootstrap --verbose=0
+cat <<EOF | /usr/bin/mysqld --datadir='./data' --user=mysql --bootstrap --verbose=0
 USE mysql;
 FLUSH PRIVILEGES;
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' identified by '${MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;


### PR DESCRIPTION
Original docker-mutillidae (https://github.com/edoz90/docker-mutillidae/) project seems not supported currently. I have forked (https://github.com/storojs72/docker-mutillidae) it and performed some changes with MariaDB settings required for newer version. Now this repository depends on forked version of mutillidae which we can maintain independently.

